### PR TITLE
V1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.leitingsd.plugins</groupId>
     <artifactId>NLKWhitelistX</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>NLKWhitelistX</name>

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/NLKWhitelistX.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/NLKWhitelistX.java
@@ -1,0 +1,306 @@
+package net.leitingsd.plugins.nlkwhitelistx;
+
+import com.google.inject.Inject;
+import net.leitingsd.plugins.nlkwhitelistx.command.WlMainCommand;
+import net.leitingsd.plugins.nlkwhitelistx.database.DatabaseManager;
+import net.leitingsd.plugins.nlkwhitelistx.listener.FallbackListener;
+import net.leitingsd.plugins.nlkwhitelistx.listener.PostLoginListener;
+import net.leitingsd.plugins.nlkwhitelistx.listener.WhitelistListener;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistCheckResult;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+import org.slf4j.Logger;
+import org.yaml.snakeyaml.Yaml;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Plugin(
+        id = "nlkwhitelistx",
+        name = "NLKWhitelistX",
+        version = "1.3.0",
+        description = "A whitelist plugin for Velocity",
+        authors = {"leitingsd"}
+)
+public class NLKWhitelistX {
+
+    private static final String PLUGIN_VERSION = "1.3.0";
+    private final ProxyServer server;
+    private final Logger logger;
+    private final Path dataDirectory;
+    private DatabaseManager databaseManager;
+    private WhitelistManager whitelistManager;
+    private Map<String, String> messages = new HashMap<>();
+    private boolean useMojangAPI;
+    private String thirdPartyAPI;
+    
+    // 管理员列表
+    private List<String> adminPlayers = new ArrayList<>();
+    
+    // 临时缓存，用于在 LoginEvent 和 PostLoginEvent 之间传递检查结果
+    private final Map<UUID, WhitelistCheckResult> loginResultCache = new ConcurrentHashMap<>();
+
+    @Inject
+    public NLKWhitelistX(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
+        this.server = server;
+        this.logger = logger;
+        this.dataDirectory = dataDirectory;
+    }
+
+    private boolean initialized = false;
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    @Subscribe
+    public void onProxyInitialization(ProxyInitializeEvent event) {
+        // Initialize database manager
+        databaseManager = new DatabaseManager(this);
+
+        try {
+            loadConfig();
+            // loadConfig 现在会抛出异常如果数据库初始化失败，所以这里的 isConnected 检查可能多余，但保留无害
+            if (!databaseManager.isConnected()) {
+                throw new IllegalStateException("数据库未完成初始化");
+            }
+            whitelistManager = new WhitelistManager(databaseManager, useMojangAPI, thirdPartyAPI, logger);
+            initialized = true;  // 初始化成功
+            logger.info("NLKWhitelistX 完成初始化");
+        } catch (Exception e) {
+            logger.error("插件初始化失败，请检查控制台输出，仅允许部分命令注册",e);
+            initialized = false;
+        }
+
+        registerCommands();
+        registerListeners();
+    }
+
+    public void loadConfig() {
+        try {
+            if (!Files.exists(dataDirectory)) {
+                Files.createDirectories(dataDirectory);
+            }
+            Path configPath = dataDirectory.resolve("config.yml");
+            
+            // 检查并更新配置文件
+            checkAndUpdateConfig(configPath);
+            
+            Yaml yaml = new Yaml();
+            try (InputStream input = Files.newInputStream(configPath)) {
+                Map<String, Object> config = yaml.load(input);
+                messages = (Map<String, String>) config.get("messages");
+                Object adminsObj = config.get("admins");
+                if (adminsObj instanceof List) {
+                    adminPlayers = (List<String>) adminsObj;
+                } else {
+                    adminPlayers = new ArrayList<>();
+                }
+                Map<String, Object> apiConfig = (Map<String, Object>) config.get("api");
+                if (apiConfig != null) {
+                    Object useMojangAPIObj = apiConfig.get("useMojangAPI");
+                    if (useMojangAPIObj instanceof Boolean ) {
+                        useMojangAPI = (Boolean) useMojangAPIObj;
+                    } else if (useMojangAPIObj instanceof String) {
+                        useMojangAPI = Boolean.parseBoolean((String) useMojangAPIObj);
+                    } else {
+                        useMojangAPI = true;  // 默认情况下使用MojangAPI
+                    }
+
+                    Object thirdPartyAPIObj = apiConfig.get("thirdPartyAPI");
+                    thirdPartyAPI = (thirdPartyAPIObj != null) ? thirdPartyAPIObj.toString().trim() : "";
+
+                    // 当 useMojangAPI == false 时读取第三方 API
+                    if (!useMojangAPI) {
+                        if (thirdPartyAPI.isEmpty()) {
+                            logger.error(getMessage("api-thirdparty-missing"));
+                        } else {
+                            logger.info(MessageFormat.format(getMessage("api-using-thirdparty"), thirdPartyAPI));
+                        }
+                    } else {
+                        logger.info(getMessage("api-using-mojang"));
+                    }
+                } else {
+                    useMojangAPI = true;
+                    thirdPartyAPI = "";
+                    logger.warn(getMessage("api-missing"));
+                }
+                databaseManager.init((Map<String, Object>) config.get("database"));
+            }
+        } catch (IOException e) {
+            logger.error("无法加载配置文件", e);
+            throw new RuntimeException("配置文件加载失败", e);
+        } catch (Exception e) {
+            throw e; 
+        }
+    }
+    
+    private void checkAndUpdateConfig(Path configPath) throws IOException {
+        if (!Files.exists(configPath)) {
+            try (InputStream in = getClass().getResourceAsStream("/config.yml")) {
+                Files.copy(in, configPath);
+            }
+            return;
+        }
+
+        // 读取当前配置文件的版本号
+        String currentVersion = null;
+        try (BufferedReader reader = Files.newBufferedReader(configPath, StandardCharsets.UTF_8)) {
+            String line;
+            Pattern versionPattern = Pattern.compile("^#\\s*Version:\\s*([\\d\\.]+)");
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = versionPattern.matcher(line);
+                if (matcher.find()) {
+                    currentVersion = matcher.group(1);
+                    break;
+                }
+            }
+        }
+
+        // 如果版本不匹配，备份旧配置并生成新配置
+        if (currentVersion == null || !currentVersion.equals(PLUGIN_VERSION)) {
+            logger.warn("检测到旧版本配置文件 (当前: {}, 最新: {})，正在更新...", currentVersion, PLUGIN_VERSION);
+            String backupName = "config_backup_v" + (currentVersion != null ? currentVersion : "unknown") + ".yml";
+            Path backupPath = dataDirectory.resolve(backupName);
+            if (Files.exists(backupPath)) {
+                String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+                backupName = "config_backup_v" + (currentVersion != null ? currentVersion : "unknown") + "_" + timestamp + ".yml";
+                backupPath = dataDirectory.resolve(backupName);
+            }
+            
+            Files.move(configPath, backupPath, StandardCopyOption.REPLACE_EXISTING);
+            logger.info("旧配置文件已备份至: {}", backupPath.getFileName());
+            try (InputStream in = getClass().getResourceAsStream("/config.yml")) {
+                Files.copy(in, configPath);
+            }
+            logger.info("已生成新的配置文件，请根据需要将旧配置迁移回来。");
+        }
+    }
+
+    private void registerCommands() {
+        server.getCommandManager().register(server.getCommandManager().metaBuilder("wl").build(), new WlMainCommand(this));
+    }
+
+    private void registerListeners() {
+        EventManager eventManager = server.getEventManager();
+        Optional<PluginContainer> container = server.getPluginManager().fromInstance(this);
+        container.ifPresent(pluginContainer -> {
+            if (initialized) {
+                eventManager.register(pluginContainer, new WhitelistListener(this, whitelistManager, logger));
+                eventManager.register(pluginContainer, new PostLoginListener(this));
+            } else {
+                logger.warn("插件未完成初始化，进入降级模式");
+                // 注册降级模式监听器，拒绝所有玩家
+                eventManager.register(pluginContainer, new FallbackListener(this));
+            }
+        });
+    }
+    
+    // 重载监听器
+    public void reloadListeners() {
+        EventManager eventManager = server.getEventManager();
+        Optional<PluginContainer> container = server.getPluginManager().fromInstance(this);
+        
+        container.ifPresent(pluginContainer -> {
+            eventManager.unregisterListeners(pluginContainer);
+            if (initialized) {
+                if (whitelistManager == null) {
+                     whitelistManager = new WhitelistManager(databaseManager, useMojangAPI, thirdPartyAPI, logger);
+                }
+                
+                eventManager.register(pluginContainer, new WhitelistListener(this, whitelistManager, logger));
+                eventManager.register(pluginContainer, new PostLoginListener(this));
+                logger.info("已重新注册正常模式监听器");
+            } else {
+                eventManager.register(pluginContainer, new FallbackListener(this));
+                logger.warn("已重新注册降级模式监听器");
+            }
+        });
+    }
+    
+    // 允许外部设置 initialized 状态
+    public void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+    
+    // 允许外部更新 whitelistManager
+    public void setWhitelistManager(WhitelistManager whitelistManager) {
+        this.whitelistManager = whitelistManager;
+    }
+
+    public ProxyServer getServer() { return server; }
+
+    public Logger getLogger() { return logger; }
+
+    public Path getDataDirectory() {
+        return dataDirectory;
+    }
+
+    public DatabaseManager getDatabaseManager() {
+        return databaseManager;
+    }
+
+    public WhitelistManager getWhitelistManager() {
+        return whitelistManager;
+    }
+
+    public List<String> getAdminPlayers() {
+        return adminPlayers;
+    }
+    
+    public Map<UUID, WhitelistCheckResult> getLoginResultCache() {
+        return loginResultCache;
+    }
+
+    public String getMessage(String key, Object... args) {
+        String message = messages.getOrDefault(key, "未知消息键: " + key);
+        message = message.replace("{version}", PLUGIN_VERSION);
+        String formattedMessage = MessageFormat.format(message, args);
+        if (formattedMessage.contains("&")) {
+            formattedMessage = formattedMessage.replace('&', '§');
+        }
+        return formattedMessage;
+    }
+    
+    // 写入日志文件
+    public void logToFile(String message) {
+        try {
+            Path logFile = dataDirectory.resolve("whitelist_access.log");
+            if (!Files.exists(logFile)) {
+                Files.createFile(logFile);
+            }
+            
+            String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+            String logEntry = "[" + timestamp + "] " + message + System.lineSeparator();
+            
+            Files.write(logFile, logEntry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            logger.error("无法写入 whitelist_access.log", e);
+        }
+    }
+    
+    public boolean isUseMojangAPI() {
+        return useMojangAPI;
+    }
+
+    public String getThirdPartyAPI() {
+        return thirdPartyAPI;
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlAdd.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlAdd.java
@@ -1,0 +1,76 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WlAdd implements SimpleCommand {
+    private final NLKWhitelistX plugin;
+
+    public WlAdd(NLKWhitelistX plugin, WhitelistManager whitelistManager) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+
+        WhitelistManager whitelistManager = plugin.getWhitelistManager();
+        if (whitelistManager == null) {
+            source.sendMessage(Component.text("插件未完全初始化，无法执行此命令。"));
+            return;
+        }
+
+        if (args.length < 3) {
+            source.sendMessage(Component.text(plugin.getMessage("wladd-bad-arguments")));
+            return;
+        }
+
+        String inputPlayer = args[0];
+        String guarantor = args[1];
+        String lotnumber = args[2];
+        String description = args.length > 3 ? args[3] : "无"; // 如果没有提供备注，则使用 "无"
+        String operator;
+
+        if (source instanceof Player) {
+            operator = ((Player) source).getUsername();
+        } else {
+            operator = "Console";
+        }
+
+        CompletableFuture<String> uuidFuture = CompletableFuture.supplyAsync(() -> whitelistManager.getUUIDFromAPI(inputPlayer));
+        CompletableFuture<String> playerNameFuture = CompletableFuture.supplyAsync(() -> whitelistManager.getPlayerNameFromAPI(inputPlayer));
+
+        try {
+            String uuid = uuidFuture.get(5, TimeUnit.SECONDS);
+            String playerName = playerNameFuture.get(5, TimeUnit.SECONDS);
+
+            if (uuid == null || playerName == null) {
+                source.sendMessage(Component.text(plugin.getMessage("wladd-uuid-not-found", inputPlayer)));
+                return;
+            }
+
+            whitelistManager.addPlayerToWhitelist(playerName, operator, guarantor, lotnumber, description).thenRun(() ->
+                    source.sendMessage(Component.text(plugin.getMessage("wladd-success", playerName, operator)))
+            ).exceptionally(ex -> {
+                ex.printStackTrace();
+                source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+                return null;
+            });
+
+        } catch (TimeoutException e) {
+            source.sendMessage(Component.text(plugin.getMessage("wladd-uuid-timeout", inputPlayer)));
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", e.getMessage())));
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlCheck.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlCheck.java
@@ -1,0 +1,48 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+import java.util.concurrent.CompletableFuture;
+
+public class WlCheck implements SimpleCommand {
+
+    private final NLKWhitelistX plugin;
+
+    public WlCheck(NLKWhitelistX plugin, WhitelistManager whitelistManager) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        
+        // 动态获取 WhitelistManager
+        WhitelistManager whitelistManager = plugin.getWhitelistManager();
+        if (whitelistManager == null) {
+            source.sendMessage(Component.text("插件未完全初始化，无法执行此命令。"));
+            return;
+        }
+
+        if (args.length < 1) {
+            source.sendMessage(Component.text(plugin.getMessage("wlcheck-usage")));
+            return;
+        }
+
+        String playerName = args[0];
+
+        CompletableFuture.runAsync(() -> {
+            String uuid = whitelistManager.getUUIDFromAPI(playerName);
+            String correctName = whitelistManager.getPlayerNameFromAPI(playerName);
+
+            if (uuid != null && correctName != null) {
+                source.sendMessage(Component.text(plugin.getMessage("wlcheck-success", correctName, uuid)));
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlcheck-error")));
+            }
+        });
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlCommand.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlCommand.java
@@ -1,0 +1,27 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+
+public class WlCommand implements SimpleCommand {
+    private final NLKWhitelistX plugin;
+
+    public WlCommand(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+
+        // 从 config.yml 中读取描述信息
+        String description = plugin.getMessage("wl-command");
+
+        // 发送描述信息
+        source.sendMessage(Component.text(description));
+
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlHelp.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlHelp.java
@@ -1,0 +1,21 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+
+public class WlHelp implements SimpleCommand {
+
+    private final NLKWhitelistX plugin;
+
+    public WlHelp(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        source.sendMessage(Component.text(plugin.getMessage("wl-command")));
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlMainCommand.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlMainCommand.java
@@ -1,0 +1,85 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WlMainCommand implements SimpleCommand {
+
+    private final NLKWhitelistX plugin;
+    private final Map<String, SimpleCommand> subCommands = new HashMap<>();
+
+    public WlMainCommand(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+        registerSubCommands();
+    }
+
+    private void registerSubCommands() {
+        subCommands.put("add", new WlAdd(plugin, plugin.getWhitelistManager()));
+        subCommands.put("query", new WlQuery(plugin, plugin.getWhitelistManager()));
+        subCommands.put("reload", new WlReload(plugin));
+        subCommands.put("remove", new WlRemove(plugin, plugin.getWhitelistManager()));
+        subCommands.put("help", new WlHelp(plugin));
+        subCommands.put("check", new WlCheck(plugin, plugin.getWhitelistManager()));
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+
+        // 权限检查
+        if (!source.hasPermission("nlkwhitelist.x")) {
+            source.sendMessage(Component.text(plugin.getMessage("no-permission")));
+            return;
+        }
+
+        String[] args = invocation.arguments();
+
+        if (args.length < 1) {
+            source.sendMessage(Component.text(plugin.getMessage("wl-command"))); // 输出默认/wl
+            return;
+        }
+
+        String subCommandKey  = args[0].toLowerCase();
+
+        // 如果插件未初始化，仅允许 help / reload
+        if (!plugin.isInitialized() && !subCommandKey.equals("help") && !subCommandKey.equals("reload")) {
+            source.sendMessage(Component.text("插件初始化未完成，请检查控制台输出"));
+            return;
+        }
+
+        SimpleCommand command = subCommands.get(subCommandKey);
+        if (command != null) {
+            command.execute(new Invocation() {
+                @Override
+                public CommandSource source() {
+                    return source;
+                }
+
+                @Override
+                public String alias() {
+                    return invocation.alias();
+                }
+
+                @Override
+                public String[] arguments() {
+                    return getSubCommandArguments(args);
+                }
+            });
+        } else {
+            source.sendMessage(Component.text(plugin.getMessage("unknown-command", args[0])));
+        }
+    }
+
+    private String[] getSubCommandArguments(String[] args) {
+        if (args.length <= 1) {
+            return new String[0];
+        }
+        String[] subArgs = new String[args.length - 1];
+        System.arraycopy(args, 1, subArgs, 0, subArgs.length);
+        return subArgs;
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlQuery.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlQuery.java
@@ -1,0 +1,209 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistRecord;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+public class WlQuery implements SimpleCommand {
+    private final NLKWhitelistX plugin;
+
+    public WlQuery(NLKWhitelistX plugin, WhitelistManager whitelistManager) {
+        this.plugin = plugin;
+        // whitelistManager 参数保留以兼容旧代码，但不再存储
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        
+        // 动态获取 WhitelistManager
+        WhitelistManager whitelistManager = plugin.getWhitelistManager();
+        if (whitelistManager == null) {
+            source.sendMessage(Component.text("插件未完全初始化，无法执行此命令。"));
+            return;
+        }
+
+        if (args.length < 1) {
+            source.sendMessage(Component.text(plugin.getMessage("wlquery-bad-arguments")));
+            return;
+        }
+
+        String queryType = args[0];
+
+        switch (queryType.toLowerCase()) {
+            case "lot":
+                if (args.length < 2) {
+                    source.sendMessage(Component.text(plugin.getMessage("wlquery-bad-arguments")));
+                } else {
+                    queryByLotnumber(source, args[1], whitelistManager);
+                }
+                break;
+
+            case "list":
+                if (args.length > 1 && args[1].equalsIgnoreCase("-full")) {
+                    queryWhitelistedPlayersFull(source, whitelistManager);  // 执行详细输出
+                } else {
+                    queryWhitelistedPlayersSimple(source, whitelistManager);  // 执行简洁输出
+                }
+                break;
+
+            case "all":
+                if (args.length > 1 && args[1].equalsIgnoreCase("-full")) {
+                    queryAllRecordsFull(source, whitelistManager);  // 执行详细输出
+                } else {
+                    queryAllRecordsSimple(source, whitelistManager);  // 执行简洁输出
+                }
+                break;
+
+            default:
+                querySinglePlayer(source, queryType, whitelistManager);
+                break;
+        }
+    }
+
+    private void querySinglePlayer(CommandSource source, String player, WhitelistManager whitelistManager) {
+        whitelistManager.queryWhitelist(player).thenAccept(record -> {
+            if (record != null) {
+                String deleteAtMessage = (record.getDeleteAt() == 0) ? "无" : formatTimestamp(record.getDeleteAt());
+                String deleteOperatorMessage = (record.getDeleteOperator() != null) ? record.getDeleteOperator() : "无";
+                String deleteReasonMessage = (record.getDeleteReason() != null) ? record.getDeleteReason() : "未被删除白名单";
+                String oldIdMessage = (record.getOldid() != null) ? record.getOldid() : "无";
+                String guarantorMessage = (record.getGuarantor().equalsIgnoreCase("unknown") || record.getGuarantor().equals("-")) ? "无" : record.getGuarantor();
+
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-entry",
+                        record.getId(),
+                        record.getUuid(),
+                        record.getPlayer(),  // 显示当前玩家ID
+                        formatTimestamp(record.getTime().getTime()), // 添加时间
+                        guarantorMessage,    // 担保人
+                        record.getOperator(), // 操作员
+                        record.getLotnumber(), // 审核批次号
+                        record.getDescription() != null ? record.getDescription() : "无", // 描述
+                        oldIdMessage,         // 曾用ID
+                        deleteAtMessage,      // 删除于
+                        deleteOperatorMessage, // 删除操作员
+                        deleteReasonMessage    // 删除原因
+                )));
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private void queryByLotnumber(CommandSource source, String lotnumber, WhitelistManager whitelistManager) {
+        whitelistManager.queryByLotnumber(lotnumber).thenAccept(records -> {
+            if (records != null && !records.isEmpty()) {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-lot-header", lotnumber)));
+                for (WhitelistRecord record : records) {
+                    String oldId = (record.getOldid() != null) ? record.getOldid() : "无";
+                    String formattedOutput = record.getDeleteAt() == 0
+                            ? plugin.getMessage("wlquery-lot", lotnumber, record.getPlayer(), formatTimestamp(record.getTime().getTime()), oldId)
+                            : "§o§m" + plugin.getMessage("wlquery-lot", lotnumber, record.getPlayer(), formatTimestamp(record.getTime().getTime()), oldId) + "§r";
+                    source.sendMessage(Component.text(formattedOutput));
+                }
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private void queryWhitelistedPlayersFull(CommandSource source, WhitelistManager whitelistManager) {
+        whitelistManager.queryWhitelistedPlayers().thenAccept(records -> {
+            if (records != null && !records.isEmpty()) {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-list-full-header", records.size())));
+                for (WhitelistRecord record : records) {
+                    String oldId = (record.getOldid() != null) ? record.getOldid() : "无";
+                    source.sendMessage(Component.text(plugin.getMessage("wlquery-list-full", records.size(), record.getPlayer(), formatTimestamp(record.getTime().getTime()), oldId)));
+                }
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private void queryWhitelistedPlayersSimple(CommandSource source, WhitelistManager whitelistManager) {
+        whitelistManager.queryWhitelistedPlayers().thenAccept(records -> {
+            if (records != null && !records.isEmpty()) {
+                String players = records.stream()
+                        .map(WhitelistRecord::getPlayer)
+                        .collect(Collectors.joining(", "));
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-list", records.size(), players)));
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private void queryAllRecordsFull(CommandSource source, WhitelistManager whitelistManager) {
+        whitelistManager.queryAllRecords().thenAccept(records -> {
+            if (records != null && !records.isEmpty()) {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-all-full-header", records.size())));
+                for (WhitelistRecord record : records) {
+                    String oldId = (record.getOldid() != null) ? record.getOldid() : "无";
+                    String formattedOutput = record.getDeleteAt() == 0
+                            ? plugin.getMessage("wlquery-all-full", record.getPlayer(), formatTimestamp(record.getTime().getTime()), oldId)
+                            : "§o§m" + plugin.getMessage("wlquery-all-full", record.getPlayer(), formatTimestamp(record.getTime().getTime()), oldId) + "§r";
+                    source.sendMessage(Component.text(formattedOutput));
+                }
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private void queryAllRecordsSimple(CommandSource source, WhitelistManager whitelistManager) {
+        whitelistManager.queryAllRecords().thenAccept(records -> {
+            if (records != null && !records.isEmpty()) {
+                String players = records.stream()
+                        .map(record -> {
+                            if (record.getDeleteAt() != 0) {
+                                return "§o§m" + record.getPlayer() + "§r";
+                            } else {
+                                return record.getPlayer();
+                            }
+                        })
+                        .collect(Collectors.joining(", "));
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-all", records.size(), players)));
+            } else {
+                source.sendMessage(Component.text(plugin.getMessage("wlquery-no-data")));
+            }
+        }).exceptionally(ex -> {
+            ex.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+            return null;
+        });
+    }
+
+    private String formatTimestamp(long timestamp) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy年MM月dd日");
+        return sdf.format(new Date(timestamp));
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlReload.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlReload.java
@@ -1,0 +1,44 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.Component;
+
+public class WlReload implements SimpleCommand {
+    private final NLKWhitelistX plugin;
+
+    public WlReload(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+
+        try {
+            plugin.loadConfig();
+            plugin.setInitialized(true);
+            
+            // 重新实例化 WhitelistManager
+            WhitelistManager newWhitelistManager = new WhitelistManager(
+                plugin.getDatabaseManager(), 
+                plugin.isUseMojangAPI(), 
+                plugin.getThirdPartyAPI(), 
+                plugin.getLogger()
+            );
+            plugin.setWhitelistManager(newWhitelistManager);
+            plugin.reloadListeners();
+            
+            source.sendMessage(Component.text(plugin.getMessage("wlreload-success")));
+            
+        } catch (Exception e) {
+            plugin.setInitialized(false);
+            // 加载失败时返回降级模式监听器
+            plugin.reloadListeners();
+            source.sendMessage(Component.text(plugin.getMessage("wlreload-failure")));
+            plugin.getLogger().error("Failed to reload config.yml", e);
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlRemove.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/command/WlRemove.java
@@ -1,0 +1,76 @@
+package net.leitingsd.plugins.nlkwhitelistx.command;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WlRemove implements SimpleCommand {
+    private final NLKWhitelistX plugin;
+
+    public WlRemove(NLKWhitelistX plugin, WhitelistManager whitelistManager) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        
+        // 动态获取 WhitelistManager
+        WhitelistManager whitelistManager = plugin.getWhitelistManager();
+        if (whitelistManager == null) {
+            source.sendMessage(Component.text("插件未完全初始化，无法执行此命令。"));
+            return;
+        }
+
+        if (args.length < 2) {
+            source.sendMessage(Component.text(plugin.getMessage("wlremove-bad-arguments")));
+            return;
+        }
+
+        String inputPlayer = args[0];
+        String reason = args[1];
+        String operator;
+
+        if (source instanceof Player) {
+            operator = ((Player) source).getUsername();
+        } else {
+            operator = "Console";
+        }
+
+        // 异步请求UUID和玩家名
+        CompletableFuture<String> uuidFuture = CompletableFuture.supplyAsync(() -> whitelistManager.getUUIDFromAPI(inputPlayer));
+        CompletableFuture<String> playerNameFuture = CompletableFuture.supplyAsync(() -> whitelistManager.getPlayerNameFromAPI(inputPlayer));
+
+        try {
+            String uuid = uuidFuture.get(5, TimeUnit.SECONDS);  // 设置5秒超时
+            String playerName = playerNameFuture.get(5, TimeUnit.SECONDS);
+
+            if (uuid == null || playerName == null) {
+                source.sendMessage(Component.text(plugin.getMessage("wladd-uuid-not-found", inputPlayer)));
+                return;
+            }
+
+            whitelistManager.removePlayerFromWhitelist(playerName, reason, operator).thenRun(() ->
+                    source.sendMessage(Component.text(plugin.getMessage("wlremove-success", playerName, operator)))
+            ).exceptionally(ex -> {
+                ex.printStackTrace();
+                source.sendMessage(Component.text(plugin.getMessage("internal-error", ex.getMessage())));
+                return null;
+            });
+
+        } catch (TimeoutException e) {
+            source.sendMessage(Component.text(plugin.getMessage("wladd-uuid-timeout", inputPlayer)));
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            source.sendMessage(Component.text(plugin.getMessage("internal-error", e.getMessage())));
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/database/DatabaseManager.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/database/DatabaseManager.java
@@ -1,0 +1,112 @@
+package net.leitingsd.plugins.nlkwhitelistx.database;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import org.slf4j.Logger;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+
+public class DatabaseManager {
+
+    private final NLKWhitelistX plugin;
+    private HikariDataSource dataSource;
+
+    public DatabaseManager(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+    public void init(Map<String, Object> config) {
+        // 关闭可能存在的连接池
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+
+        Logger logger = plugin.getLogger();
+        HikariConfig hikariConfig = new HikariConfig();
+
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("MySQL JDBC 驱动程序加载失败", e);
+        }
+
+        String host = (String) config.getOrDefault("host", "localhost");
+        int port = Integer.parseInt(config.getOrDefault("port", 3306).toString());
+        String database = (String) config.getOrDefault("database", "whitelist");
+        String user = (String) config.getOrDefault("user", "root");
+        String password = (String) config.getOrDefault("password", "password");
+        boolean useSSL = Boolean.parseBoolean(config.getOrDefault("usessl", false).toString());
+        String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/?useSSL=" + useSSL;
+        hikariConfig.setUsername(user);
+        hikariConfig.setPassword(password);
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, user, password)) {
+            try (Statement statement = connection.createStatement()) {
+                // 创建数据库（如果不存在）
+                statement.executeUpdate("CREATE DATABASE IF NOT EXISTS " + database);
+                logger.info("数据库 '{}' 已检查/创建", database);
+            }
+        } catch (SQLException e) {
+            logger.error("无法创建数据库 '{}'", database, e);
+            throw new IllegalStateException("数据库初始化失败", e);
+        }
+
+        hikariConfig.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL);
+        hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+
+        if (config.containsKey("properties")) {
+            Map<String, Object> properties = (Map<String, Object>) config.get("properties");
+            properties.forEach((key, value) -> hikariConfig.addDataSourceProperty(key, value.toString()));
+        }
+
+        this.dataSource = new HikariDataSource(hikariConfig);
+        logger.info("数据库连接已初始化");
+
+        try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
+            String sql = "CREATE TABLE IF NOT EXISTS whitelist (" +
+                    "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+                    "uuid VARCHAR(36) NOT NULL, " +
+                    "player VARCHAR(255) NOT NULL, " +
+                    "oldid VARCHAR(255), " +
+                    "operator VARCHAR(255), " +
+                    "guarantor VARCHAR(255), " +
+                    "lotnumber VARCHAR(255), " +
+                    "description TEXT, " +
+                    "time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, " +
+                    "deleteAt BIGINT DEFAULT 0, " +
+                    "deleteReason TEXT, " +
+                    "deleteOperator VARCHAR(255)" +
+                    ")";
+            statement.execute(sql);
+            logger.info("表 'whitelist' 已检查/创建");
+        } catch (SQLException e) {
+            logger.error("无法创建表 'whitelist'", e);
+        }
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    public boolean isConnected() {
+        if (dataSource == null) return false;
+        try (Connection conn = getConnection()) {
+            return conn != null && !conn.isClosed();
+        } catch (SQLException e) {
+            plugin.getLogger().error("数据库连接检查失败", e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/FallbackListener.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/FallbackListener.java
@@ -1,0 +1,29 @@
+package net.leitingsd.plugins.nlkwhitelistx.listener;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.LoginEvent;
+import net.kyori.adventure.text.Component;
+
+public class FallbackListener {
+
+    private final NLKWhitelistX plugin;
+
+    public FallbackListener(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+    @Subscribe
+    public void onPlayerLogin(LoginEvent event) {
+        String playerName = event.getPlayer().getUsername();
+        plugin.getLogger().warn("降级模式拦截: 阻止玩家 {} 加入", playerName);
+        
+        // 降级模式：拒绝所有玩家加入
+        String message = plugin.getMessage("fallback-kick-message");
+        if (message.startsWith("未知消息键")) {
+            message = "插件处于降级模式，暂时无法进入服务器。";
+        }
+        
+        event.setResult(LoginEvent.ComponentResult.denied(Component.text(message)));
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/PostLoginListener.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/PostLoginListener.java
@@ -1,0 +1,43 @@
+package net.leitingsd.plugins.nlkwhitelistx.listener;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistCheckResult;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PostLoginEvent;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import java.util.List;
+import java.util.UUID;
+
+public class PostLoginListener {
+
+    private final NLKWhitelistX plugin;
+
+    public PostLoginListener(NLKWhitelistX plugin) {
+        this.plugin = plugin;
+    }
+
+    @Subscribe
+    public void onPostLogin(PostLoginEvent event) {
+        Player player = event.getPlayer();
+        UUID playerUuid = player.getUniqueId();
+        String playerName = player.getUsername();
+
+        // 检查缓存中是否有该玩家的登录结果
+        WhitelistCheckResult result = plugin.getLoginResultCache().remove(playerUuid);
+
+        if (result == WhitelistCheckResult.ALLOWED_OFFLINE) {
+            String warningMsg = plugin.getMessage("admin-api-warning", playerName);
+            Component warningComponent = Component.text(warningMsg);
+            plugin.getLogger().warn(warningMsg);
+            List<String> adminPlayers = plugin.getAdminPlayers();
+            if (adminPlayers != null && !adminPlayers.isEmpty()) {
+                for (Player onlinePlayer : plugin.getServer().getAllPlayers()) {
+                    if (adminPlayers.contains(onlinePlayer.getUsername())) {
+                        onlinePlayer.sendMessage(warningComponent);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/WhitelistListener.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/listener/WhitelistListener.java
@@ -1,0 +1,82 @@
+package net.leitingsd.plugins.nlkwhitelistx.listener;
+
+import net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistManager;
+import net.leitingsd.plugins.nlkwhitelistx.manager.WhitelistCheckResult;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.LoginEvent;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import org.slf4j.Logger;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class WhitelistListener {
+
+    private final NLKWhitelistX plugin;
+    private final WhitelistManager whitelistManager;
+    private final Logger logger;
+    private final int timeoutSeconds;
+
+    public WhitelistListener(NLKWhitelistX plugin, WhitelistManager whitelistManager, Logger logger) {
+        this.plugin = plugin;
+        this.whitelistManager = whitelistManager;
+        this.logger = logger;
+        // 超时判定，默认5秒
+        this.timeoutSeconds = 5;
+    }
+
+    @Subscribe
+    public void onPlayerLogin(LoginEvent event) {
+        Player player = event.getPlayer();
+        String playerName = player.getUsername();
+
+        try {
+            WhitelistCheckResult result = whitelistManager
+                    .checkWhitelist(playerName)
+                    .get(timeoutSeconds, TimeUnit.SECONDS);
+
+            switch (result) {
+                case ALLOWED -> {
+                    logger.info("玩家 {} 通过白名单验证。", playerName);
+                    event.setResult(LoginEvent.ComponentResult.allowed());
+                }
+                case ALLOWED_OFFLINE -> {
+                    logger.info("玩家 {} 通过离线白名单验证（API不可用）。", playerName);
+                    event.setResult(LoginEvent.ComponentResult.allowed());
+                    // 缓存
+                    plugin.getLoginResultCache().put(player.getUniqueId(), WhitelistCheckResult.ALLOWED_OFFLINE);
+                    // 记录日志
+                    plugin.logToFile("ALLOWED_OFFLINE: 玩家 " + playerName + " (" + player.getUniqueId() + ") 通过本地缓存验证进入。");
+                }
+                case NOT_WHITELISTED -> {
+                    logger.info("玩家 {} 不在白名单中，拒绝进入。", playerName);
+                    event.setResult(LoginEvent.ComponentResult.denied(
+                            Component.text(plugin.getMessage("not_whitelisted"))
+                    ));
+                    plugin.logToFile("NOT_WHITELISTED: 玩家 " + playerName + " (" + player.getUniqueId() + ") 尝试进入被拒绝。");
+                }
+                case API_ERROR -> {
+                    logger.warn("无法验证玩家 {} 的白名单状态（API错误且本地无记录）。", playerName);
+                    event.setResult(LoginEvent.ComponentResult.denied(
+                            Component.text(plugin.getMessage("api-error"))
+                    ));
+                    plugin.logToFile("API_ERROR: 玩家 " + playerName + " (" + player.getUniqueId() + ") 因API校验失败且本地校验失败被拒绝加入。");
+                }
+            }
+        } catch (TimeoutException e) {
+            logger.warn("白名单验证超时：{}", playerName);
+            event.setResult(LoginEvent.ComponentResult.denied(
+                    Component.text(plugin.getMessage("check-timeout"))
+            ));
+            plugin.logToFile("TIMEOUT: 玩家 " + playerName + " 验证超时。");
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("检查玩家 {} 白名单时发生错误。", playerName, e);
+            event.setResult(LoginEvent.ComponentResult.denied(
+                    Component.text(plugin.getMessage("internal-error"))
+            ));
+            plugin.logToFile("ERROR: 玩家 " + playerName + " 验证时发生内部错误: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistCheckResult.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistCheckResult.java
@@ -1,0 +1,8 @@
+package net.leitingsd.plugins.nlkwhitelistx.manager;
+
+public enum WhitelistCheckResult {
+    ALLOWED,          // 在白名单中 (API正常)
+    ALLOWED_OFFLINE,  // 在白名单中 (API异常，但本地校验通过)
+    NOT_WHITELISTED,  // 不在白名单中
+    API_ERROR         // 无法连接 Mojang Service 或第三方 API，且本地无记录
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistManager.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistManager.java
@@ -1,0 +1,444 @@
+package net.leitingsd.plugins.nlkwhitelistx.manager;
+
+import net.leitingsd.plugins.nlkwhitelistx.database.DatabaseManager;
+import org.slf4j.Logger;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WhitelistManager {
+    private final DatabaseManager databaseManager;
+    private final boolean useMojangAPI;
+    private final String thirdPartyAPI;
+    private final Logger logger;
+
+    public WhitelistManager(DatabaseManager databaseManager, boolean useMojangAPI, String thirdPartyAPI, Logger logger) {
+        this.databaseManager = databaseManager;
+        this.useMojangAPI = useMojangAPI;
+        this.thirdPartyAPI = thirdPartyAPI;
+        this.logger = logger;
+    }
+
+    private static final ExecutorService WHITELIST_EXECUTOR =
+            Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public String getUUIDFromAPI(String player) {
+        String apiUrl;
+        if (useMojangAPI) {
+            apiUrl = "https://api.mojang.com/users/profiles/minecraft/" + player;
+        } else if (thirdPartyAPI != null && !thirdPartyAPI.isEmpty()) {
+            apiUrl = thirdPartyAPI.replace("{username}", player);
+        } else {
+            logger.warn("API URL 为空，无法获取 UUID");
+            return null;
+        }
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiUrl))
+                    .timeout(Duration.ofSeconds(3))
+                    .GET()
+                    .build();
+
+            // 异步请求
+            HttpResponse<String> response = HTTP_CLIENT
+                    .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .get(4, java.util.concurrent.TimeUnit.SECONDS); // 超时4秒
+
+            if (response.statusCode() == 200) {
+                return extractUUID(response.body());
+            } else {
+                logger.warn("API 请求失败: {}", response.statusCode());
+                return null;
+            }
+        } catch (Exception e) {
+            logger.error("获取UUID时发生错误", e);
+            return null;
+        }
+    }
+
+    public CompletableFuture<WhitelistCheckResult> checkWhitelist(String player) {
+        return CompletableFuture.supplyAsync(() -> {
+            String uuid = getUUIDFromAPI(player);
+            if (uuid == null) {
+                // 无法连接API，尝试本地数据库校验
+                return checkLocalWhitelist(player);
+            }
+
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT player FROM whitelist WHERE uuid = ? AND deleteAt = 0";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setString(1, uuid);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (resultSet.next()) {
+                            String currentID = resultSet.getString("player");
+                            if (!currentID.equals(player)) {
+                                updatePlayerID(uuid, player, currentID);
+                            }
+                            return WhitelistCheckResult.ALLOWED;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+
+            return WhitelistCheckResult.NOT_WHITELISTED;
+        }, WHITELIST_EXECUTOR);
+    }
+
+    // 当API不可用时执行本地数据库校验
+    private WhitelistCheckResult checkLocalWhitelist(String player) {
+        try (Connection connection = databaseManager.getConnection()) {
+            // 尝试通过玩家名直接查询
+            String sql = "SELECT uuid, player FROM whitelist WHERE player = ? AND deleteAt = 0";
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.setString(1, player);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        // 本地存在该玩家记录且未被删除
+                        logger.info("API不可用，但本地数据库验证通过: {}", player);
+                        return WhitelistCheckResult.ALLOWED_OFFLINE; // 返回离线验证通过状态
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            logger.error("本地白名单校验时发生SQL异常", e);
+        }
+        // 本地无匹配记录或发生错误，返回 API_ERROR 触发原有逻辑
+        return WhitelistCheckResult.API_ERROR;
+    }
+
+    private String extractUUID(String jsonResponse) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode rootNode = mapper.readTree(jsonResponse);
+            return rootNode.get("id").asText();
+        } catch (Exception e) {
+            logger.error("在提取UUID时发生错误", e);
+            return null;
+        }
+    }
+
+    public String getPlayerNameFromAPI(String player) {
+        String apiUrl;
+        if (useMojangAPI) {
+            apiUrl = "https://api.mojang.com/users/profiles/minecraft/" + player;
+        } else if (thirdPartyAPI != null && !thirdPartyAPI.isEmpty()) {
+            apiUrl = thirdPartyAPI.replace("{username}", player);
+        } else {
+            logger.warn("API URL 为空，无法获取玩家名称");
+            return null;
+        }
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiUrl))
+                    .timeout(Duration.ofSeconds(3))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = HTTP_CLIENT
+                    .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .get(4, java.util.concurrent.TimeUnit.SECONDS);
+
+            if (response.statusCode() == 200) {
+                return extractPlayerName(response.body());
+            } else {
+                logger.warn("API 请求失败: {}", response.statusCode());
+                return null;
+            }
+        } catch (Exception e) {
+            logger.error("获取玩家名称时发生错误", e);
+            return null;
+        }
+    }
+
+    private String extractPlayerName(String jsonResponse) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode rootNode = mapper.readTree(jsonResponse);
+            return rootNode.get("name").asText();
+        } catch (Exception e) {
+            logger.error("在提取玩家名称时发生错误", e);
+            return null;
+        }
+    }
+
+    public CompletableFuture<Boolean> isPlayerWhitelisted(String player) {
+        return CompletableFuture.supplyAsync(() -> {
+            String uuid = getUUIDFromAPI(player);
+            if (uuid == null) {
+                return false;
+            }
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT player FROM whitelist WHERE uuid = ? AND deleteAt = 0";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setString(1, uuid);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (resultSet.next()) {
+                            String currentID = resultSet.getString("player");
+                            if (!currentID.equals(player)) {
+                                updatePlayerID(uuid, player, currentID);
+                            }
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+            return false;
+        }, WHITELIST_EXECUTOR);
+    }
+
+    private void updatePlayerID(String uuid, String newID, String oldID) {
+        try (Connection connection = databaseManager.getConnection()) {
+            String sql = "UPDATE whitelist SET player = ?, oldid = ? WHERE uuid = ?";
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.setString(1, newID);
+                statement.setString(2, oldID);
+                statement.setString(3, uuid);
+                statement.executeUpdate();
+            }
+        } catch (SQLException e) {
+            logger.error("更新玩家ID时发生错误 （事件ID: 13 - 数据库错误）", e);
+        }
+    }
+
+    public CompletableFuture<Void> addPlayerToWhitelist(String inputPlayerName, String operator, String guarantor, String lotnumber, String description) {
+        return CompletableFuture.runAsync(() -> {
+            String uuid = getUUIDFromAPI(inputPlayerName);
+            String playerName = getPlayerNameFromAPI(inputPlayerName);
+
+            if (uuid == null || playerName == null) {
+                logger.warn("无法获取UUID或玩家名称, 无法添加玩家到白名单");
+                return;
+            }
+
+            try (Connection connection = databaseManager.getConnection()) {
+                // 修改查询语句以获取 player 列
+                String checkSql = "SELECT player FROM whitelist WHERE uuid = ?";
+                try (PreparedStatement checkStatement = connection.prepareStatement(checkSql)) {
+                    checkStatement.setString(1, uuid);
+                    try (ResultSet resultSet = checkStatement.executeQuery()) {
+                        if (resultSet.next()) {
+                            // 从ResultSet中正确获取 player 列的值
+                            String oldPlayerName = resultSet.getString("player");
+                            String oldid = oldPlayerName.equals(playerName) ? null : oldPlayerName;
+
+                            // 执行更新操作
+                            String updateSql = "UPDATE whitelist SET player = ?, oldid = ?, operator = ?, guarantor = ?, lotnumber = ?, description = ?, deleteAt = 0, deleteReason = NULL, deleteOperator = NULL WHERE uuid = ?";
+                            try (PreparedStatement updateStatement = connection.prepareStatement(updateSql)) {
+                                updateStatement.setString(1, playerName);
+                                updateStatement.setString(2, oldid);
+                                updateStatement.setString(3, operator);
+                                updateStatement.setString(4, guarantor);
+                                updateStatement.setString(5, lotnumber);
+                                updateStatement.setString(6, description);
+                                updateStatement.setString(7, uuid);
+                                updateStatement.executeUpdate();
+                            }
+                        } else {
+                            // 插入新的记录
+                            String insertSql = "INSERT INTO whitelist (uuid, player, oldid, operator, guarantor, lotnumber, description) VALUES (?, ?, NULL, ?, ?, ?, ?)";
+                            try (PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
+                                insertStatement.setString(1, uuid);
+                                insertStatement.setString(2, playerName);
+                                insertStatement.setString(3, operator);
+                                insertStatement.setString(4, guarantor);
+                                insertStatement.setString(5, lotnumber);
+                                insertStatement.setString(6, description);
+                                insertStatement.executeUpdate();
+                            }
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+        }, WHITELIST_EXECUTOR);
+    }
+
+    public CompletableFuture<WhitelistRecord> queryWhitelist(String player) {
+        return CompletableFuture.supplyAsync(() -> {
+            String uuid = getUUIDFromAPI(player);
+            if (uuid == null) {
+                return null;
+            }
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT * FROM whitelist WHERE uuid = ?";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setString(1, uuid);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (resultSet.next()) {
+                            return new WhitelistRecord(
+                                    resultSet.getLong("id"),
+                                    resultSet.getString("uuid"),
+                                    resultSet.getString("player"),
+                                    resultSet.getString("oldid"),
+                                    resultSet.getString("operator"),
+                                    resultSet.getString("guarantor"),
+                                    resultSet.getString("lotnumber"),
+                                    resultSet.getString("description"),
+                                    resultSet.getTimestamp("time"),
+                                    resultSet.getLong("deleteAt"),
+                                    resultSet.getString("deleteOperator"),
+                                    resultSet.getString("deleteReason")
+                            );
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+            return null;
+        }, WHITELIST_EXECUTOR);
+    }
+
+    public CompletableFuture<Void> removePlayerFromWhitelist(String player, String reason, String operator) {
+        return CompletableFuture.runAsync(() -> {
+            String uuid = getUUIDFromAPI(player);
+            if (uuid == null) {
+                logger.warn("无法获取UUID, 无法从白名单移除玩家");
+                return;
+            }
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "UPDATE whitelist SET deleteAt = ?, deleteReason = ?, deleteOperator = ? WHERE uuid = ? AND deleteAt = 0";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setLong(1, System.currentTimeMillis());
+                    statement.setString(2, reason);
+                    statement.setString(3, operator);
+                    statement.setString(4, uuid);
+                    int affectedRows = statement.executeUpdate();
+                    if (affectedRows == 0) {
+                        logger.warn("移除操作未成功，未找到匹配的UUID记录。");
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+        });
+    }
+
+    // 根据批次号查询玩家
+    public CompletableFuture<List<WhitelistRecord>> queryByLotnumber(String lotnumber) {
+        return CompletableFuture.supplyAsync(() -> {
+            List<WhitelistRecord> records = new ArrayList<>();
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT * FROM whitelist WHERE lotnumber = ?";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setString(1, lotnumber);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        while (resultSet.next()) {
+                            records.add(new WhitelistRecord(
+                                    resultSet.getLong("id"),
+                                    resultSet.getString("uuid"),
+                                    resultSet.getString("player"),
+                                    resultSet.getString("oldid"),
+                                    resultSet.getString("operator"),
+                                    resultSet.getString("guarantor"),
+                                    resultSet.getString("lotnumber"),
+                                    resultSet.getString("description"),
+                                    resultSet.getTimestamp("time"),
+                                    resultSet.getLong("deleteAt"),
+                                    resultSet.getString("deleteOperator"),
+                                    resultSet.getString("deleteReason")
+                            ));
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+            return records;
+        }, WHITELIST_EXECUTOR);
+    }
+
+    // 查询所有白名单中的玩家
+    public CompletableFuture<List<WhitelistRecord>> queryWhitelistedPlayers() {
+        return CompletableFuture.supplyAsync(() -> {
+            List<WhitelistRecord> records = new ArrayList<>();
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT * FROM whitelist WHERE deleteAt = 0";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        while (resultSet.next()) {
+                            records.add(new WhitelistRecord(
+                                    resultSet.getLong("id"),
+                                    resultSet.getString("uuid"),
+                                    resultSet.getString("player"),
+                                    resultSet.getString("oldid"),
+                                    resultSet.getString("operator"),
+                                    resultSet.getString("guarantor"),
+                                    resultSet.getString("lotnumber"),
+                                    resultSet.getString("description"),
+                                    resultSet.getTimestamp("time"),
+                                    resultSet.getLong("deleteAt"),
+                                    resultSet.getString("deleteOperator"),
+                                    resultSet.getString("deleteReason")
+                            ));
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+            return records;
+        }, WHITELIST_EXECUTOR);
+    }
+
+    // 查询所有记录（包括已移除白名单的玩家）
+    public CompletableFuture<List<WhitelistRecord>> queryAllRecords() {
+        return CompletableFuture.supplyAsync(() -> {
+            List<WhitelistRecord> records = new ArrayList<>();
+            try (Connection connection = databaseManager.getConnection()) {
+                String sql = "SELECT * FROM whitelist";
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        while (resultSet.next()) {
+                            records.add(new WhitelistRecord(
+                                    resultSet.getLong("id"),
+                                    resultSet.getString("uuid"),
+                                    resultSet.getString("player"),
+                                    resultSet.getString("oldid"),
+                                    resultSet.getString("operator"),
+                                    resultSet.getString("guarantor"),
+                                    resultSet.getString("lotnumber"),
+                                    resultSet.getString("description"),
+                                    resultSet.getTimestamp("time"),
+                                    resultSet.getLong("deleteAt"),
+                                    resultSet.getString("deleteOperator"),
+                                    resultSet.getString("deleteReason")
+                            ));
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("SQL异常", e);
+            }
+            return records;
+        }, WHITELIST_EXECUTOR);
+    }
+}

--- a/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistRecord.java
+++ b/src/main/java/net/leitingsd/plugins/nlkwhitelistx/manager/WhitelistRecord.java
@@ -1,0 +1,82 @@
+package net.leitingsd.plugins.nlkwhitelistx.manager;
+
+import java.sql.Timestamp;
+
+public class WhitelistRecord {
+    private long id;
+    private String uuid;
+    private String player;
+    private String oldid;
+    private String operator;
+    private String guarantor;
+    private String lotnumber;
+    private String description;
+    private Timestamp time;
+    private long deleteAt;
+    private String deleteOperator;
+    private String deleteReason;
+
+    public WhitelistRecord(long id, String uuid, String player, String oldid, String operator, String guarantor, String lotnumber, String description, Timestamp time, long deleteAt, String deleteOperator, String deleteReason) {
+        this.id = id;
+        this.uuid = uuid;
+        this.player = player;
+        this.oldid = oldid;
+        this.operator = operator;
+        this.guarantor = guarantor;
+        this.lotnumber = lotnumber;
+        this.description = description;
+        this.time = time;
+        this.deleteAt = deleteAt;
+        this.deleteOperator = deleteOperator;
+        this.deleteReason = deleteReason;
+    }
+
+
+    public long getId() {
+        return id;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getPlayer() {
+        return player;
+    }
+
+    public String getOldid() {
+        return oldid;
+    }
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public String getGuarantor() {
+        return guarantor;
+    }
+
+    public String getLotnumber() {
+        return lotnumber;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Timestamp getTime() {
+        return time;
+    }
+
+    public long getDeleteAt() {
+        return deleteAt;
+    }
+
+    public String getDeleteOperator() {
+        return deleteOperator;
+    }
+
+    public String getDeleteReason() {
+        return deleteReason;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # NLKWhitelistX
-# Version: 1.2.1
+# Version: 1.3.0
 
 # 配置MySQL数据库
 database:
@@ -18,34 +18,50 @@ database:
 
 # 配置API选择项
 api:
-  useMojangAPI: true
-  # 如果设置为 false，使用第三方API，默认值为 true 使用Mojang API，
+  useMojangAPI: ture
+  # 如果设置为true，将使用Mojang API，否则使用第三方API
   thirdPartyAPI: "https://api.mojang.com/users/profiles/minecraft/{username}"
   # 此处默认设置为Mojang API，用于请求正版玩家的UUID数据；
   # 如果不使用Mojang API，请在此输入第三方API的URL，例如：https://api.example.com/users/profiles/{username}
 
-# 配置插件输出的消息
+# 管理员列表（指定用于接收API离线警告）
+admins:
+  - "AdminPlayer1"
+  - "AdminPlayer2"
+
 messages:
+  admin-api-warning: "&c[警告] 玩家 {0} 通过本地缓存验证进入服务器，当前 Mojang API 可能不可用。"
   not_whitelisted: "You are not whitelisted on this server."
   internal-error: "发生了一个内部错误：{0}"
+  fallback-kick-message: "&c白名单插件处于维护模式，暂时无法进入服务器，请联系管理员。"
   reject-join-no-whitelist: ":( 此 ID 还未处于白名单中"
   reject-join-incorrect-cases: "您正在使用 {0} 加入服务器，但您申请的白名单为 {1}，请保持用户名大小写一致"
-  wladd-bad-arguments: "参数错误：请使用 /wladd <玩家ID> <担保人（若无请填 - ）> <审核批次号（担保请填 000）> <白名单添加备注>"
+  api-missing: "&e未找到 'api' 配置段，已回退至默认设置（使用 Mojang API）"
+  api-thirdparty-missing: "配置错误: useMojangAPI=false 但未提供 thirdPartyAPI URL！"
+  api-using-thirdparty: "使用第三方 API: {0}"
+  api-using-mojang: "使用 Mojang 官方 API"
+  reject-join-api-error: "&e无法验证白名单状态，请稍后重试。"
+  reject-join-check-timeout: "&e白名单验证失败，请稍后再试。"
+  reject-join-internal-error: "&c服务器内部错误，请联系管理员。"
+  wladd-bad-arguments: "参数错误：请使用 /wl add <玩家ID> <担保人（若无请填 - ）> <审核批次号（担保请填 000）> <白名单添加备注>"
   wladd-success: "玩家 {0} (ID: {1}) 已成功添加到白名单。"
   wladd-uuid-not-found: "无法找到玩家 {0} 的 UUID，添加白名单失败。"
   wladd-uuid-timeout: "获取玩家 {0} 的 UUID 超时，添加白名单失败。"
-  wladd-error-no-updates: "添加失败，此玩家可能已经在白名单中。请使用 /wlquery <玩家ID> 查询白名单详情。"
-  wlremove-bad-arguments: "参数错误：请使用 /wlremove <玩家ID> <删除原因>"
+  wladd-error-no-updates: "添加失败，此玩家可能已经在白名单中。请使用 /wl query <玩家ID> 查询白名单详情。"
+  wlremove-bad-arguments: "参数错误：请使用 /wl remove <玩家ID> <删除原因>"
   wlremove-error-no-updates: "删除失败，未找到与指定玩家 ID 对应的白名单记录。"
   wlremove-success: "玩家 {0} 已成功从白名单中移除。"
-  wlquery-bad-arguments: "参数错误：请使用 /wlquery <玩家ID> 或通过 /wl 查询详细语法"
+  wlquery-bad-arguments: "参数错误：请使用 /wl query <玩家ID> 或通过 /wl 查询详细语法"
   wlquery-entry: |
-    序列号: {0} - UUID: {1} - 玩家ID：{2}
+    ===== NLKWhitelistX 查询结果 =====
+    序号: {0} - UUID: {1} 
+    玩家ID：{2}
     添加时间：{3}
     担保人：{4} 操作员：{5}
     审核批次号：{6}
     描述：{7}
     曾用ID：{8}
+    ===== 如果其已被删除 =====
     删除于：{9} 删除操作员：{10}
     删除原因：{11}
   wlquery-entry-simple: |
@@ -73,9 +89,13 @@ messages:
   delete-time: "删除时间：{0}"
   wlreload-success: "配置文件已成功重新加载。"
   wlreload-failure: "配置文件重新加载失败，请检查控制台的错误日志。"
-  no-permission: "&c你没有权限执行此命令: {0}"
+  no-permission: "&c你没有权限执行此命令"
   # 描述
   unknown-command: "&c未知命令: {0}，请使用 /wl 查询详细语法"
+  wlcheck-usage: "&c用法: /wl check <玩家ID>"
+  wlcheck-success: "&a查询结果如下：玩家ID：“{0}”，UUID：“{1}”"
+  wlcheck-error: "&c未查询到该玩家"
+
   wl-command: |
     &lNLKWhitelistX &7- 版本 {version}
     &7一个基于Velocity的白名单插件。
@@ -88,7 +108,9 @@ messages:
     &f/wl query lot <审核批次号>  &7- 查询同一批次玩家的数据
     &f/wl query list (-full)  &7- 查询所有白名单玩家的数据（可添加 -full 选项输出更详细的数据）
     &f/wl query all (-full)  &7- 查询数据库内所有玩家的数据，包括已被移除白名单的玩家（可添加 -full 选项输出更详细的数据）
+    &f/wl check <玩家ID> &7- 调用 Mojang API 查询玩家数据
     &f/wl reload &7- 重载插件
+
 
 # 在 wlquery-entry 中，所有占位符代表意义如下：
 #  {0} 数据库中的序列号
@@ -103,4 +125,3 @@ messages:
 #  {9} 删除于
 #  {10} 删除操作员
 #  {11} 删除原因
-

--- a/src/main/resources/velocity-plugin.yml
+++ b/src/main/resources/velocity-plugin.yml
@@ -1,7 +1,7 @@
 {
   "id": "nlkwhitelistx",
   "name": "NLKWhitelistX",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A whitelist plugin for Velocity",
   "authors": ["leitingsd"],
   "dependencies": [
@@ -10,7 +10,7 @@
       "optional": false
     }
   ],
-  "main": "com.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX",
+  "main": "net.leitingsd.plugins.nlkwhitelistx.NLKWhitelistX",
   "commands": {
     "wlquery": {
       "aliases": ["query", "wq"],
@@ -30,4 +30,3 @@
     }
   }
 }
-


### PR DESCRIPTION
1. 重写检查状态判定，对原先的连接时白名单检查状态方法进行修改，用于返回玩家的不可连接原因（无白名单、网络故障与插件异常）；
2. 强制检测 Config 版本号是否与插件版本对应，如果不匹配将重新生成 Config 配置信息；
3. 新增/wl check [玩家ID] 调用 Mojang API 查询正版账号与其UUID；
4. 新增 降级模式；

- 4.1 降级模式仅保留 /wl、/wl help 与 /wl reload 方法；
- 4.2 降级模式仅在插件预载失败时启用（如JDBC初始化失败）；
- 4.3 降级模式下，拒绝所有玩家加入请求并提示；
- 4.4 降级模式只能通过重载退出；

5. 新增管理员名单，在 Config 内进行定义，用于接收来自插件的警告与提示信息；
6. 新增管理员权限检查，只有拥有 nlkwhitelistx.* 权限时才可操作白名单；
7. 玩家加入时在白名单检查过程中因超时或回报非200状态拦截时，对数据库进行离线对照，检查其是否存在白名单。
如该玩家拥有白名单，存入记录于 ./config/nlkwhitelist/whitelist_access.log 后临时放行并在游戏内对管理员输出提示；如该玩家无白名单，返回白名单检查错误/API离线警告；
